### PR TITLE
Fix: use esm wrapper strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@channel.io/channel-web-sdk-loader",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@channel.io/channel-web-sdk-loader",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "commitizen": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -2,22 +2,27 @@
   "name": "@channel.io/channel-web-sdk-loader",
   "version": "1.1.2",
   "description": "Official Channel Web SDK Loader",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.esm.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs.js"
+      }
+    }
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.esm.js",
-      "require": "./dist/index.cjs.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
   "sideEffects": false,
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npm run build:cjs && npm run build:esm",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc -p tsconfig.esm.json && mv dist/index.js dist/index.esm.js && mv dist/index.d.ts dist/index.d.mts && cp dist/index.esm.js dist/index.esm.mjs",
     "build:cjs": "tsc -p tsconfig.cjs.json && mv dist/index.js dist/index.cjs.js",
-    "build:esm": "tsc -p tsconfig.esm.json && mv dist/index.js dist/index.esm.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "commit": "git-cz",
     "build:typedoc": "typedoc src/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/channel-web-sdk-loader",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Official Channel Web SDK Loader",
   "exports": {
     ".": {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [ ] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [ ] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [ ] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
  - Android: Chrome, Samsung Internet
  - iOS: Safari, Chrome,

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made -->
- use .mjs wrapper strategy

## Details
<!-- Please elaborate description of the changes -->
- `Typescript 4.7+`: `.mts`, `.cts` 파일을 구분합니다.
- package.json > `type`: 해당 필드가 없으면 해당 패키지는 `CommonJS`로 간주됩니다.
- 확장자가 `.mjs`이면, type 필드에 상관없이 해당 파일은 `ES Module`로 간주됩니다.
- package.json > `exports`
  - [내부 각 조건에서 `types` 필드가 가장 먼저 설정되어야 합니다.](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)
  - `CJS`, `ESM` 각각 entrypoint 별 다른 declaration 파일이 설정되어야 합니다.(내용이 동일하더라도)
- change-version: `v1.1.2` -> `v1.1.3`

## Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->
- https://nodejs.org/api/packages.html#approach-1-use-an-es-module-wrapper
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing
- https://nodejs.org/api/packages.html#dual-package-hazard