### PR TITLE
refactor(set-page): add `profile` optional parameter to set page API method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,7 +341,7 @@ export function hideMessenger() {
 
 /**
  * Opens a chat interface
- * 
+ *
  * - Reveals the `messenger` if hidden.
  * - For an undefined `chatId`, a new chat is created. Any provided `message` populates the chat input. The support bot initializes if active.
  * - If a chat with the given `chatId` exists, the chat will open, and the `message` parameter will be disregarded.
@@ -358,14 +358,14 @@ export function openChat(chatId?: string | number, message?: string) {
 
 /**
  * Initiates a chat by triggering a specified support bot.
- * 
+ *
  * - Reveals the `messenger` if hidden.
  * - Activates the support bot identified by the given `supportBotId`.
  * - No action is taken if `supportBotId` is not specified.
  * - Shows an error page if a support bot with the specified `supportBotId` does not exist.
  * - Populates the chat input with `message` upon support bot completion if provided.
  * - Caution: Utilizing this function outside a click event may cause issues in iOS Safari.
- * 
+ *
  * @param {string} supportBotId - Identifier of the targeted support bot.
  * @param {string | undefined} message - Optional message to populate the chat input field post support bot action.
  * @see https://developers.channel.io/docs/web-channelio#opensupportbot
@@ -379,7 +379,7 @@ export interface EventProperty {
 }
 /**
  * Tracks user event.
- * 
+ *
  * - If the event is new, it gets created.
  * - Data might take from minutes to hours to appear on the `Desk`.
  *
@@ -522,7 +522,7 @@ export interface UpdateUserInfo {
 }
 /**
  * Updates user information.
- * 
+ *
  * @param {UpdateUserInfo} userInfo - Object containing user information to be updated.
  * @param {Callback} [callback] - Optional callback function to be executed upon completion.
  * @see https://developers.channel.io/docs/web-channelio#updateuser
@@ -555,12 +555,13 @@ export function removeTags(tags: string[], callback?: Callback) {
  * Sets the current page.
  * - Page can be used instead of canonical URL.
  * @param {string} page - The page to set. Do not pass null or undefined. Use `resetPage` to clear.
+ * @param {Record<string, any>} profile - The user chat profile value.
  * @see [ChannelIO: setpage API](https://developers.channel.io/docs/web-channelio#setpage)
  * @see [page Glossary](https://developers.channel.io/docs/page)
  * @see [canonical-url Glossary](https://developers.channel.io/docs/canonical-url)
  */
-export function setPage(page: string) {
-  safeChannelIO('setPage', page);
+export function setPage(page: string, profile?: Record<string, any>) {
+  safeChannelIO('setPage', page, profile)
 }
 
 /**


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [ ] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
  - Android: Chrome, Samsung Internet
  - iOS: Safari, Chrome,

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made -->

setPage 메소드에 누락되어있던 profile 파라미터를 추가합니다.

## Details
<!-- Please elaborate description of the changes -->

## Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

## References
<!-- Please list any other resources or points the reviewer should be aware of -->